### PR TITLE
list items are prepending

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -113,5 +113,5 @@ function addItemToDOM(text, completed) {
   buttons.appendChild(complete);
   item.appendChild(buttons);
 
-  list.appendChild(item);
+  list.insertBefore(item, list.firstChild);
 }


### PR DESCRIPTION
This PR addresses issue https://github.com/cn10xdev/todo/issues/7

Using list.insertBefore(item, list.firstChild) function instead of list.appendChild(item) at the last line of the code, by this we can add items at the top