### PR TITLE
Issue#1

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -19,7 +19,7 @@ document.getElementById('add').addEventListener('click', function() {
 });
 
 document.getElementById('item').addEventListener('keydown', function (e) {
-  var value = this.value;
+  var value = this.value.trim();
   if ((e.keyCode === 13 || e.keyCode === 'NumpadEnter') && value) {
     addItem(value);
   }

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -113,5 +113,5 @@ function addItemToDOM(text, completed) {
   buttons.appendChild(complete);
   item.appendChild(buttons);
 
-  list.appendChild(item);
+  list.insertBefore(item, list.firstChild);
 }


### PR DESCRIPTION
This PR addresses issue https://github.com/cn10xdev/todo/issues/7

-Before whitespaces were removed only on `click` EventListener, Now on  `keydown `also i have added `value.trim()` to remove whitespaces
-By modifying this code, now the action taken from the keyboard  also will be trimmed (removing white spaces) before adding it to the item
